### PR TITLE
Add CompileResultWithTemplate function

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -24,6 +24,17 @@ func CompileResult(name string, rslt *result, opts *Options) (*template.Template
 	// Initialize the options.
 	opts = initializeOptions(opts)
 
+	// Create a template.
+	t := template.New(name)
+
+	return CompileResultWithTemplate(t, rslt, opts)
+}
+
+// CompileResultWithTemplate compiles the parsed result and associates it with t.
+func CompileResultWithTemplate(t *template.Template, rslt *result, opts *Options) (*template.Template, error) {
+	// Initialize the options.
+	opts = initializeOptions(opts)
+
 	var err error
 
 	// Create a buffer.
@@ -62,8 +73,8 @@ func CompileResult(name string, rslt *result, opts *Options) (*template.Template
 		includeBfs[path] = bf
 	}
 
-	// Create a template.
-	t := template.New(name).Delims(opts.DelimLeft, opts.DelimRight)
+	// Set Delimiters.
+	t.Delims(opts.DelimLeft, opts.DelimRight)
 
 	// Set FuncMaps.
 	t.Funcs(template.FuncMap{


### PR DESCRIPTION
Hello,

I added `CompileResultWithTemplate` function to Ace to receive `*template.Template` value which is created somewhere as its argument and append compiled template to the value. Of course, we can append the compiled template to others by using `AddParsedTree` but it doesn't allow us to use `FuncMap` defined in others because `*template.Template` doesn't have a function returns `FuncMap`. In this implementation, `FuncMap` defined in passed `*template.Templates` value is merged with Ace own builtin FuncMap and can be called in templates.
