### PR TITLE
Add some simple compile tests and fix to use a double quoted template value in a tag attribute

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -49,6 +49,14 @@ func TestLineCompile(t *testing.T) {
 			template: "div class=\"dialog {{ if eq .Attr `important` }}color-red text-big{{end}}\" text",
 			expect: "<div class=\"dialog {{if eq .Attr `important`}}color-red text-big{{end}}\">text</div>",
 		},
+		{
+			template: "div class=\"dialog {{ if eq .Attr \"important\" }}color-red{{end}}\" text",
+			expect: "<div class=\"dialog {{if eq .Attr \"important\"}}color-red{{end}}\">text</div>",
+		},
+		{
+			template: "div class=\"dialog {{ if eq .Attr \"important\" }}color-red text-big{{end}}\" text",
+			expect: "<div class=\"dialog {{if eq .Attr \"important\"}}color-red text-big{{end}}\">text</div>",
+		},
 	} {
 		name, filepath := "dummy", "dummy.ace"
 		base := NewFile(filepath, []byte(this.template))


### PR DESCRIPTION
Hi,

I wrote some codes to allow to use a double quoted template value in a double quoted tag attribute. Here is the example

```
div class="dialog {{ if eq .Attr "important" }}color-red text-big{{end}}" text
```

Without my fix, it doesn't work. Of course, instead of it,

```
div class="dialog {{ if eq .Attr `important` }}color-red text-big{{end}}" text
```

works but I think it is straightforward allowing both a double quote and a backtick quote in an attribute.

Before fixing this, not to break current behavior, I added simple compile tests to check whether the compiler returns expected values. Those mightn't be perfect so please be careful to merge this.
