### PR TITLE
Sort HTML attributes by key

### DIFF
--- a/html_tag.go
+++ b/html_tag.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -78,7 +79,16 @@ func (e *htmlTag) WriteTo(w io.Writer) (int64, error) {
 	}
 	// Write attributes.
 	if len(e.attributes) > 0 {
-		for k, v := range e.attributes {
+		// to get consistent rendering, we have to sort the keys
+		var keys []string
+		for k := range e.attributes {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := e.attributes[k]
 			bf.WriteString(space)
 			bf.WriteString(k)
 			if v != "" {


### PR DESCRIPTION
HTML attributes are backed by a Go map, and since Go 1 the iteration order has been random.

This is not a problem for the browsers, but is a problem when using changed content as a way of detecting which files to deploy to a server.

This commit fixes that by ordering by attribute key.

Fixes #37
