### PR TITLE
introduce convenience function to clear cache

### DIFF
--- a/ace.go
+++ b/ace.go
@@ -61,3 +61,10 @@ func setCache(name string, tpl template.Template) {
 	cache[name] = tpl
 	cacheMutex.Unlock()
 }
+
+// FlushCache clears all cached templates.
+func FlushCache() {
+       cacheMutex.Lock()
+       cache = make(map[string]template.Template)
+       cacheMutex.Unlock()
+}


### PR DESCRIPTION
In the situation that you use build-in caching and need to change your templates without stopping the process. 

Comes in handy when you use a reload function in your application.