### PR TITLE
Overridable "class" attribute

### DIFF
--- a/html_tag.go
+++ b/html_tag.go
@@ -23,9 +23,6 @@ const (
 	attributeNameID = "id"
 )
 
-// AttributeNameClass is a variable constant.
-var AttributeNameClass = "class"
-
 // No close tag names
 var noCloseTagNames = []string{
 	tagNameBr,
@@ -73,7 +70,7 @@ func (e *htmlTag) WriteTo(w io.Writer) (int64, error) {
 	// Write classes.
 	if len(e.classes) > 0 {
 		bf.WriteString(space)
-		bf.WriteString(AttributeNameClass)
+		bf.WriteString(e.opts.AttributeNameClass)
 		bf.WriteString(equal)
 		bf.WriteString(doubleQuote)
 		for i, class := range e.classes {
@@ -169,7 +166,7 @@ func (e *htmlTag) setAttributes() error {
 				return fmt.Errorf("multiple IDs are specified [file: %s][line: %d]", e.ln.fileName(), e.ln.no)
 			}
 			e.id = v
-		case AttributeNameClass:
+		case e.opts.AttributeNameClass:
 			e.classes = append(e.classes, strings.Split(v, space)...)
 		default:
 			e.attributes = append(e.attributes, htmlAttribute{k, v})

--- a/html_tag.go
+++ b/html_tag.go
@@ -20,9 +20,11 @@ const (
 
 // Attribute names
 const (
-	attributeNameID    = "id"
-	attributeNameClass = "class"
+	attributeNameID = "id"
 )
+
+// AttributeNameClass is a variable constant.
+var AttributeNameClass = "class"
 
 // No close tag names
 var noCloseTagNames = []string{
@@ -71,7 +73,7 @@ func (e *htmlTag) WriteTo(w io.Writer) (int64, error) {
 	// Write classes.
 	if len(e.classes) > 0 {
 		bf.WriteString(space)
-		bf.WriteString(attributeNameClass)
+		bf.WriteString(AttributeNameClass)
 		bf.WriteString(equal)
 		bf.WriteString(doubleQuote)
 		for i, class := range e.classes {
@@ -167,7 +169,7 @@ func (e *htmlTag) setAttributes() error {
 				return fmt.Errorf("multiple IDs are specified [file: %s][line: %d]", e.ln.fileName(), e.ln.no)
 			}
 			e.id = v
-		case attributeNameClass:
+		case AttributeNameClass:
 			e.classes = append(e.classes, strings.Split(v, space)...)
 		default:
 			e.attributes = append(e.attributes, htmlAttribute{k, v})

--- a/options.go
+++ b/options.go
@@ -4,9 +4,10 @@ import "html/template"
 
 // Defaults
 const (
-	defaultExtension  = "ace"
-	defaultDelimLeft  = "{{"
-	defaultDelimRight = "}}"
+	defaultExtension          = "ace"
+	defaultDelimLeft          = "{{"
+	defaultDelimRight         = "}}"
+	defaultAttributeNameClass = "class"
 )
 
 // Options represents options for the template engine.
@@ -17,6 +18,8 @@ type Options struct {
 	DelimLeft string
 	// DelimRight represents a right delimiter for the html template.
 	DelimRight string
+	// AttributeNameClass is the attribute name for classes.
+	AttributeNameClass string
 	// DynamicReload represents a flag which means whether Ace reloads
 	// templates dynamically.
 	// This option should only be true in development.
@@ -48,6 +51,10 @@ func initializeOptions(opts *Options) *Options {
 
 	if opts.DelimRight == "" {
 		opts.DelimRight = defaultDelimRight
+	}
+
+	if opts.AttributeNameClass == "" {
+		opts.AttributeNameClass = defaultAttributeNameClass
 	}
 
 	return opts


### PR DESCRIPTION
I'm compiling ace templates for React's [jsx](https://facebook.github.io/react/docs/jsx-in-depth.html)(1) to transform html blocks into React classes. Being JavaScript code and all, the "class" attribute becomes a keyword and must be written as "className". That's an explicit requirement of React.

This shouldn't be an option in ace, I'll be fine with the `attributeNameClass` redeclared as a `var` and made public. `ace.AttributeNameClass = "className"` in my code would do the trick.