### PR TITLE
Option for closing tags list

### DIFF
--- a/ace.go
+++ b/ace.go
@@ -12,7 +12,7 @@ var cacheMutex = new(sync.RWMutex)
 // and cached if the "DynamicReload" option are not set.
 func Load(basePath, innerPath string, opts *Options) (*template.Template, error) {
 	// Initialize the options.
-	opts = initializeOptions(opts)
+	opts = InitializeOptions(opts)
 
 	name := basePath + colon + innerPath
 

--- a/compile.go
+++ b/compile.go
@@ -22,7 +22,7 @@ const (
 // CompileResult compiles the parsed result to the template.Template.
 func CompileResult(name string, rslt *result, opts *Options) (*template.Template, error) {
 	// Initialize the options.
-	opts = initializeOptions(opts)
+	opts = InitializeOptions(opts)
 
 	// Create a template.
 	t := template.New(name)
@@ -33,7 +33,7 @@ func CompileResult(name string, rslt *result, opts *Options) (*template.Template
 // CompileResultWithTemplate compiles the parsed result and associates it with t.
 func CompileResultWithTemplate(t *template.Template, rslt *result, opts *Options) (*template.Template, error) {
 	// Initialize the options.
-	opts = initializeOptions(opts)
+	opts = InitializeOptions(opts)
 
 	var err error
 

--- a/html_tag.go
+++ b/html_tag.go
@@ -9,29 +9,13 @@ import (
 
 // Tag names
 const (
-	tagNameBr    = "br"
-	tagNameDiv   = "div"
-	tagNameHr    = "hr"
-	tagNameImg   = "img"
-	tagNameInput = "input"
-	tagNameLink  = "link"
-	tagNameMeta  = "meta"
+	tagNameDiv = "div"
 )
 
 // Attribute names
 const (
 	attributeNameID = "id"
 )
-
-// No close tag names
-var noCloseTagNames = []string{
-	tagNameBr,
-	tagNameHr,
-	tagNameImg,
-	tagNameInput,
-	tagNameLink,
-	tagNameMeta,
-}
 
 // htmlAttribute represents an HTML attribute.
 type htmlAttribute struct {
@@ -183,7 +167,7 @@ func (e *htmlTag) setAttributes() error {
 
 // noCloseTag returns true is the HTML tag has no close tag.
 func (e *htmlTag) noCloseTag() bool {
-	for _, name := range noCloseTagNames {
+	for name := range e.opts.NoCloseTagNames {
 		if e.tagName == name {
 			return true
 		}

--- a/html_tag.go
+++ b/html_tag.go
@@ -167,7 +167,7 @@ func (e *htmlTag) setAttributes() error {
 
 // noCloseTag returns true is the HTML tag has no close tag.
 func (e *htmlTag) noCloseTag() bool {
-	for name := range e.opts.NoCloseTagNames {
+	for _, name := range e.opts.NoCloseTagNames {
 		if e.tagName == name {
 			return true
 		}

--- a/options.go
+++ b/options.go
@@ -10,6 +10,16 @@ const (
 	defaultAttributeNameClass = "class"
 )
 
+// Default NoCloseTagNames
+var defaultNoCloseTagNames = map[string]struct{}{
+	"br":    struct{}{},
+	"hr":    struct{}{},
+	"img":   struct{}{},
+	"input": struct{}{},
+	"link":  struct{}{},
+	"meta":  struct{}{},
+}
+
 // Options represents options for the template engine.
 type Options struct {
 	// Extension represents an extension of files.
@@ -20,6 +30,8 @@ type Options struct {
 	DelimRight string
 	// AttributeNameClass is the attribute name for classes.
 	AttributeNameClass string
+	// NoCloseTagNames defines a set of tags which should not be closed.
+	NoCloseTagNames map[string]struct{}
 	// DynamicReload represents a flag which means whether Ace reloads
 	// templates dynamically.
 	// This option should only be true in development.
@@ -35,8 +47,8 @@ type Options struct {
 	FuncMap template.FuncMap
 }
 
-// initializeOptions initializes the options.
-func initializeOptions(opts *Options) *Options {
+// InitializeOptions initializes the options.
+func InitializeOptions(opts *Options) *Options {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -55,6 +67,12 @@ func initializeOptions(opts *Options) *Options {
 
 	if opts.AttributeNameClass == "" {
 		opts.AttributeNameClass = defaultAttributeNameClass
+	}
+	if opts.NoCloseTagNames == nil {
+		opts.NoCloseTagNames = make(map[string]struct{}, len(defaultNoCloseTagNames))
+		for name := range defaultNoCloseTagNames {
+			opts.NoCloseTagNames[name] = struct{}{}
+		}
 	}
 
 	return opts

--- a/options.go
+++ b/options.go
@@ -11,13 +11,13 @@ const (
 )
 
 // Default NoCloseTagNames
-var defaultNoCloseTagNames = map[string]struct{}{
-	"br":    struct{}{},
-	"hr":    struct{}{},
-	"img":   struct{}{},
-	"input": struct{}{},
-	"link":  struct{}{},
-	"meta":  struct{}{},
+var defaultNoCloseTagNames = []string{
+	"br",
+	"hr",
+	"img",
+	"input",
+	"link",
+	"meta",
 }
 
 // Options represents options for the template engine.
@@ -31,7 +31,7 @@ type Options struct {
 	// AttributeNameClass is the attribute name for classes.
 	AttributeNameClass string
 	// NoCloseTagNames defines a set of tags which should not be closed.
-	NoCloseTagNames map[string]struct{}
+	NoCloseTagNames []string
 	// DynamicReload represents a flag which means whether Ace reloads
 	// templates dynamically.
 	// This option should only be true in development.
@@ -69,11 +69,25 @@ func InitializeOptions(opts *Options) *Options {
 		opts.AttributeNameClass = defaultAttributeNameClass
 	}
 	if opts.NoCloseTagNames == nil {
-		opts.NoCloseTagNames = make(map[string]struct{}, len(defaultNoCloseTagNames))
-		for name := range defaultNoCloseTagNames {
-			opts.NoCloseTagNames[name] = struct{}{}
-		}
+		opts.NoCloseTagNames = make([]string, len(defaultNoCloseTagNames))
+		copy(opts.NoCloseTagNames, defaultNoCloseTagNames)
 	}
 
 	return opts
+}
+
+// AddNoCloseTagName appends name to .NoCloseTagNames set.
+func (opts *Options) AddNoCloseTagName(name string) {
+	opts.NoCloseTagNames = append(opts.NoCloseTagNames, name)
+}
+
+// DeleteNoCloseTagName deletes name from .NoCloseTagNames set.
+func (opts *Options) DeleteNoCloseTagName(name string) {
+	var newset []string
+	for _, n := range opts.NoCloseTagNames {
+		if n != name {
+			newset = append(newset, n)
+		}
+	}
+	opts.NoCloseTagNames = newset
 }

--- a/parse.go
+++ b/parse.go
@@ -5,7 +5,7 @@ import "strings"
 // ParseSource parses the source and returns the result.
 func ParseSource(src *source, opts *Options) (*result, error) {
 	// Initialize the options.
-	opts = initializeOptions(opts)
+	opts = InitializeOptions(opts)
 
 	rslt := newResult(nil, nil, nil)
 


### PR DESCRIPTION
Ace has predefined list of tag names to NOT be closed. It's handy to have an option to provide the list.
If I'm producing XML, I'd have it empty.

Code changes notes:
- The list is kept in a `map[string]struct{}` as the size of `struct{}` is zero.
- Initializing func makes a copy of `defaultNoCloseTagNames` for `opts.NoCloseTagNames`, otherwise plain assignment would create a reference to the default (as it is a map) and it could be modified outside ace.

I also took the opportunity to make `initializeOptions` public. It becomes complex to re-do what the func does in non-ace code when it passes non-nil *ace.Options to ace.Load etc.
