### PR TITLE
Pretty-print formatter

### DIFF
--- a/action.go
+++ b/action.go
@@ -30,6 +30,13 @@ func (e *action) WriteTo(w io.Writer) (int64, error) {
 
 }
 
+func (e *action) IsBlockElement() bool {
+	return e.parent.IsBlockElement()
+}
+func (e *action) IsControlElement() bool {
+	return true
+}
+
 // newAction creates and returns an action.
 func newAction(ln *line, rslt *result, src *source, parent element, opts *Options) *action {
 	return &action{

--- a/element.go
+++ b/element.go
@@ -25,6 +25,8 @@ type element interface {
 	CanHaveChildren() bool
 	InsertBr() bool
 	SetLastChild(lastChild bool)
+	IsBlockElement() bool
+	IsControlElement() bool
 }
 
 // newElement creates and returns an element.

--- a/element_base.go
+++ b/element_base.go
@@ -36,6 +36,12 @@ func (e *elementBase) Base() *elementBase {
 func (e *elementBase) CanHaveChildren() bool {
 	return true
 }
+func (e *elementBase) IsBlockElement() bool {
+	return false
+}
+func (e *elementBase) IsControlElement() bool {
+	return false
+}
 
 // InsertBr returns false.
 // This method should be overrided by a struct which contains
@@ -57,6 +63,11 @@ func (e *elementBase) writeChildren(bf *bytes.Buffer) (int64, error) {
 			child.SetLastChild(true)
 		}
 
+		if e.opts.formatter != nil {
+			if i, err := e.opts.formatter.OpeningElement(bf, child); err != nil {
+				return int64(i), err
+			}
+		}
 		if i, err := child.WriteTo(bf); err != nil {
 			return int64(i), err
 		}

--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,51 @@
+package ace
+
+import "bytes"
+import "strings"
+
+// File represents a file.
+type outputFormatter interface {
+	OpeningElement(*bytes.Buffer, element) (int, error)
+	ClosingElement(*bytes.Buffer, element) (int, error)
+	WritingTextValue(*bytes.Buffer, element) (int, error)
+}
+
+type Formatter struct {
+	indent string
+}
+
+func newFormatter(indent string) outputFormatter {
+	f := &Formatter{
+		indent: indent,
+	}
+	return f
+}
+
+func (f *Formatter) OpeningElement(bf *bytes.Buffer, e element) (int, error) {
+	if e.IsControlElement() {
+		return 0, nil
+	}
+
+	base := e.Base()
+	if base.parent != nil && base.parent.IsBlockElement() {
+		return f.writeIndent(bf, base.ln.indent)
+	}
+	return 0, nil
+}
+func (f *Formatter) ClosingElement(bf *bytes.Buffer, e element) (int, error) {
+	if e.IsBlockElement() {
+		return f.writeIndent(bf, e.Base().ln.indent)
+	}
+	return 0, nil
+}
+func (f *Formatter) WritingTextValue(bf *bytes.Buffer, e element) (int, error) {
+	if e.IsBlockElement() {
+		return f.writeIndent(bf, e.Base().ln.indent+1)
+	}
+	return 0, nil
+}
+
+func (f *Formatter) writeIndent(bf *bytes.Buffer, depth int) (int, error) {
+	indent := "\n" + strings.Repeat(f.indent, depth)
+	return bf.WriteString(indent)
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,96 @@
+package ace
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var innerTemplate string = `
+= content inner
+  section
+    h1 hello
+`
+
+func TestFormatter(t *testing.T) {
+
+	inner, _ := ioutil.TempFile("", "inner")
+	inner.WriteString(innerTemplate)
+	inner.Close()
+
+	os.Rename(inner.Name(), inner.Name()+".ace")
+	defer os.Remove(inner.Name() + ".ace")
+
+	for i, this := range []struct {
+		template string
+		expect   string
+	}{
+		{
+			template: `
+a
+  span foo
+`,
+			expect: `<a><span>foo</span></a>`,
+		},
+		{
+			template: `
+div
+  span foo
+`,
+			expect: `<div>
+ <span>foo</span>
+</div>`,
+		},
+		{
+			template: `
+section
+  div
+    {{if true}}
+      span foo
+    {{end}}
+  div text
+`,
+			expect: `<section>
+ <div>
+   <span>foo</span>
+ </div>
+ <div>
+  text
+ </div>
+</section>`,
+		},
+		{
+			template: `
+body
+  = yield inner
+`,
+			expect: `<body>
+ 
+ <section>
+  <h1>
+   hello
+  </h1>
+ </section>
+</body>`,
+		},
+	} {
+		base, _ := ioutil.TempFile("", "base")
+
+		base.WriteString(this.template)
+		base.Close()
+		os.Rename(base.Name(), base.Name()+".ace")
+		defer os.Remove(base.Name() + ".ace")
+
+		tpl, _ := Load(base.Name(), inner.Name(), &Options{
+			Indent: " ",
+		})
+		buf := new(bytes.Buffer)
+		tpl.Execute(buf, map[string]string{})
+
+		compiled := buf.String()
+		if compiled != this.expect {
+			t.Errorf("[%d] Compiler didn't return an expected value, got %v but expected %v", i, compiled, this.expect)
+		}
+	}
+}

--- a/helper_method_content.go
+++ b/helper_method_content.go
@@ -38,6 +38,10 @@ func (e *helperMethodContent) WriteTo(w io.Writer) (int64, error) {
 	return int64(i), err
 }
 
+func (e *helperMethodContent) IsBlockElement() bool {
+	return true
+}
+
 // newHelperMethodContent creates and returns a helper method content.
 func newHelperMethodContent(ln *line, rslt *result, src *source, parent element, opts *Options) (*helperMethodContent, error) {
 	if len(ln.tokens) < 3 || ln.tokens[2] == "" {

--- a/html_tag.go
+++ b/html_tag.go
@@ -17,6 +17,41 @@ const (
 	attributeNameID = "id"
 )
 
+var inlineElements = map[string]bool{
+	"b":        true,
+	"big":      true,
+	"i":        true,
+	"small":    true,
+	"tt":       true,
+	"abbr":     true,
+	"acronym":  true,
+	"cite":     true,
+	"code":     true,
+	"dfn":      true,
+	"em":       true,
+	"kbd":      true,
+	"strong":   true,
+	"samp":     true,
+	"time":     true,
+	"var":      true,
+	"a":        true,
+	"bdo":      true,
+	"br":       true,
+	"img":      true,
+	"map":      true,
+	"object":   true,
+	"q":        true,
+	"script":   true,
+	"span":     true,
+	"sub":      true,
+	"sup":      true,
+	"button":   true,
+	"input":    true,
+	"label":    true,
+	"select":   true,
+	"textarea": true,
+}
+
 // htmlAttribute represents an HTML attribute.
 type htmlAttribute struct {
 	key   string
@@ -83,6 +118,9 @@ func (e *htmlTag) WriteTo(w io.Writer) (int64, error) {
 
 	// Write a text value
 	if e.textValue != "" {
+		if e.opts.formatter != nil {
+			e.opts.formatter.WritingTextValue(&bf, e)
+		}
 		bf.WriteString(e.textValue)
 	}
 
@@ -97,6 +135,9 @@ func (e *htmlTag) WriteTo(w io.Writer) (int64, error) {
 
 	// Write a close tag.
 	if !e.noCloseTag() {
+		if e.opts.formatter != nil {
+			e.opts.formatter.ClosingElement(&bf, e)
+		}
 		bf.WriteString(lt)
 		bf.WriteString(slash)
 		bf.WriteString(e.tagName)
@@ -174,6 +215,15 @@ func (e *htmlTag) noCloseTag() bool {
 	}
 
 	return false
+}
+
+// true if the element is inline one
+func (e *htmlTag) IsBlockElement() bool {
+	if inline, found := inlineElements[e.tagName]; found {
+		return !inline
+	} else {
+		return true
+	}
 }
 
 // newHTMLTag creates and returns an HTML tag.

--- a/line.go
+++ b/line.go
@@ -65,7 +65,7 @@ func (l *line) fileName() string {
 	return l.file.path + dot + l.opts.Extension
 }
 
-// childOf returns true is the line is a child of the element.
+// childOf returns true if the line is a child of the element.
 func (l *line) childOf(parent element) (bool, error) {
 	var ok bool
 	var err error

--- a/options.go
+++ b/options.go
@@ -38,6 +38,9 @@ type Options struct {
 	DynamicReload bool
 	// BaseDir represents a base directory of the Ace templates.
 	BaseDir string
+	// Indent string used for indentation.
+	Indent    string
+	formatter outputFormatter
 	// Asset loads and returns the asset for the given name.
 	// If this function is set, Ace load the template data from
 	// this function instead of the template files.
@@ -71,6 +74,10 @@ func InitializeOptions(opts *Options) *Options {
 	if opts.NoCloseTagNames == nil {
 		opts.NoCloseTagNames = make([]string, len(defaultNoCloseTagNames))
 		copy(opts.NoCloseTagNames, defaultNoCloseTagNames)
+	}
+
+	if opts.Indent != "" {
+		opts.formatter = newFormatter(opts.Indent)
 	}
 
 	return opts


### PR DESCRIPTION
I'm using ace for rendering HTML emails and I found ace produces HTML without any carriage returns.
I've created pretty-print formatter since [https://www.ietf.org/rfc/rfc1652.txt](SMTP) says a line should be less than 1000 bytes. 

With following code and  `base.ace` ,
```
package main

import (
  "github.com/yosssi/ace"
  "os"
)

func main() {
  tpl, _ := ace.Load("base", "", &ace.Options{
    Indent: "  ",
  })
  tpl.Execute(os.Stdout, map[string]string{})
}
```

```
html
  body
    h1 hello
```
produces indented HTML.
```
<html>
  <body>
    <h1>
      hello
    </h1>
  </body>
</html>
```
